### PR TITLE
Declarations

### DIFF
--- a/Code/Implementations/Native/CCL/describe-optimize.lisp
+++ b/Code/Implementations/Native/CCL/describe-optimize.lisp
@@ -1,15 +1,27 @@
 (cl:in-package #:trucler-native-ccl)
 
-(defmethod trucler:describe-optimize
-    ((client client) (env null))
-  (describe-optimize *null-lexical-environment*))
+(defmethod trucler:describe-declaration
+    ((client client) (env null) identifier)
+  (describe-declaration *null-lexical-environment* identifier))
 
-(defmethod trucler:describe-optimize
-    ((client client) (env ccl::lexical-environment))
+(defmethod trucler:describe-declaration
+    ((client client) (env ccl::lexical-environment) (id (eql 'cl:optimize)))
   (describe-optimize env))
 
-(defmethod trucler:describe-optimize
-    ((client client) (env ccl::definition-environment))
+(defmethod trucler:describe-declaration
+    ((client client) (env ccl::lexical-environment) (id (eql 'cl:declaration)))
+  (make-instance 'declarations-description
+    :declarations ccl::*nx-known-declarations*))
+
+(defmethod trucler:describe-declaration
+    ((client client) (env ccl::lexical-environment) identifier)
+  (if (member identifier ccl::*nx-known-declarations*)
+      (make-instance 'user-declaration-description :name identifier)
+      nil))
+
+(defmethod trucler:describe-declaration
+    ((client client) (env ccl::definition-environment) identifier)
+  (declare (ignore identifier))
   nil)
 
 (defun describe-optimize (env)

--- a/Code/Implementations/Native/CCL/query-classes.lisp
+++ b/Code/Implementations/Native/CCL/query-classes.lisp
@@ -75,3 +75,11 @@
 (defclass optimize-description
     (trucler:optimize-description)
   ())
+
+(defclass declarations-description
+    (trucler:declarations-description)
+  ())
+
+(defclass user-declaration-description
+    (trucler:user-declaration-description)
+  ())

--- a/Code/Implementations/Native/SBCL/describe-optimize.lisp
+++ b/Code/Implementations/Native/SBCL/describe-optimize.lisp
@@ -1,11 +1,11 @@
 (cl:in-package #:trucler-native-sbcl)
 
-(defmethod trucler:describe-optimize
-    ((client client) (env null))
-  (trucler:describe-optimize client *null-lexical-environment*))
+(defmethod trucler:describe-declaration
+    ((client client) (env null) identifier)
+  (trucler:describe-declaration client *null-lexical-environment* identifier))
 
-(defmethod trucler:describe-optimize
-    ((client client) (env sb-kernel:lexenv))
+(defmethod trucler:describe-declaration
+    ((client client) (env sb-kernel:lexenv) (id (eql 'cl:optimize)))
   (let ((policy (or (sb-c::lexenv-policy env)
                     sb-c::*policy*)))
     (make-instance 'optimize-description
@@ -14,3 +14,15 @@
       :debug (sb-c::policy-quality policy 'debug)
       :space (sb-c::policy-quality policy 'space)
       :safety (sb-c::policy-quality policy 'safety))))
+
+(defmethod trucler:describe-declaration
+    ((client client) (env sb-kernel:lexenv) (id (eql 'cl:declaration)))
+  (make-instance 'declarations-description
+    :declarations (copy-list sb-int:*recognized-declarations*)))
+
+(defmethod trucler:describe-declaration
+    ((client client) (env sb-kernel:lexenv) identifier)
+  (if (member identifier sb-int:*recognized-declarations*)
+      (make-instance 'user-declaration-description
+        :name identifier)
+      nil))

--- a/Code/Implementations/Native/SBCL/query-classes.lisp
+++ b/Code/Implementations/Native/SBCL/query-classes.lisp
@@ -112,3 +112,11 @@
 (defclass optimize-description
     (trucler:optimize-description)
   ())
+
+(defclass declarations-description
+    (trucler:declarations-description)
+  ())
+
+(defclass user-declaration-description
+    (trucler:user-declaration-description)
+  ())

--- a/Code/Implementations/Native/Test/lexical-assertions.lisp
+++ b/Code/Implementations/Native/Test/lexical-assertions.lisp
@@ -151,7 +151,7 @@
        (space nil space-p)
        (safety nil safety-p)
      &environment env)
-  (let ((description (trucler:describe-optimize *client* env)))
+  (let ((description (trucler:describe-declaration *client* env 'cl:optimize)))
     (check-type description trucler:optimize-description)
     (when speed-p
       (assert (= (trucler:speed description) speed)))

--- a/Code/Implementations/Reference/augmentation-methods.lisp
+++ b/Code/Implementations/Reference/augmentation-methods.lisp
@@ -113,35 +113,40 @@
 
 (defmethod trucler:add-speed
     ((client client) (environment environment) value)
-  (let ((description (trucler:describe-optimize client environment)))
+  (let ((description
+          (trucler:describe-declaration client environment 'cl:optimize)))
     (trucler:augment-with-optimize-description
      client environment
      (trucler:merge-speed client description value))))
 
 (defmethod trucler:add-compilation-speed
     ((client client) (environment environment) value)
-  (let ((description (trucler:describe-optimize client environment)))
+  (let ((description
+          (trucler:describe-declaration client environment 'cl:optimize)))
     (trucler:augment-with-optimize-description
      client environment
      (trucler:merge-compilation-speed client description value))))
 
 (defmethod trucler:add-debug
     ((client client) (environment environment) value)
-  (let ((description (trucler:describe-optimize client environment)))
+  (let ((description
+          (trucler:describe-declaration client environment 'cl:optimize)))
     (trucler:augment-with-optimize-description
      client environment
      (trucler:merge-debug client description value))))
 
 (defmethod trucler:add-safety
     ((client client) (environment environment) value)
-  (let ((description (trucler:describe-optimize client environment)))
+  (let ((description
+          (trucler:describe-declaration client environment 'cl:optimize)))
     (trucler:augment-with-optimize-description
      client environment
      (trucler:merge-safety client description value))))
 
 (defmethod trucler:add-space
     ((client client) (environment environment) value)
-  (let ((description (trucler:describe-optimize client environment)))
+  (let ((description
+          (trucler:describe-declaration client environment 'cl:optimize)))
     (trucler:augment-with-optimize-description
      client environment
      (trucler:merge-space client description value))))

--- a/Code/Implementations/Reference/query-methods.lisp
+++ b/Code/Implementations/Reference/query-methods.lisp
@@ -61,11 +61,13 @@
          (description (find tag descriptions :test #'eql :key #'trucler:name)))
     (check-restriction environment description)))
 
-(defmethod trucler:describe-optimize ((client client) (environment environment))
+(defmethod trucler:describe-declaration
+    ((client client) (environment environment) (identifier (eql 'cl:optimize)))
   (let* ((description (optimize-description environment)))
     (when (null description)
       (let* ((global-environment (global-environment environment))
-             (global-description (trucler:describe-optimize client global-environment)))
+             (global-description
+               (trucler:describe-declaration client global-environment identifier)))
         (setf description global-description)
         (unless (null global-description)
           ;; Cache the global description locally.

--- a/Code/packages.lisp
+++ b/Code/packages.lisp
@@ -28,6 +28,7 @@
            #:expansion-mixin
            #:inline-mixin
            #:inline-data-mixin
+           #:declarations-mixin
            #:speed-mixin
            #:compilation-speed-mixin
            #:debug-mixin
@@ -69,9 +70,12 @@
            #:describe-tag
            ;; Class for tag description.
            #:tag-description
-           ;; Generic function for optimize information.
-           #:describe-optimize
-           ;; Class for optimize description.
+           ;; Generic function for declaration information.
+           #:describe-declaration
+           ;; Classes for declaration descriptions.
+           #:declaration-description
+           #:user-declaration-description
+           #:declarations-description
            #:optimize-description
            ;; Function for finding the global environment.
            #:global-environment
@@ -88,6 +92,7 @@
            #:value
            #:expansion
            #:expander
+           #:declarations
            #:speed
            #:compilation-speed
            #:debug

--- a/Code/query-classes.lisp
+++ b/Code/query-classes.lisp
@@ -88,8 +88,18 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
-;;; OPTIMIZE-DESCRIPTION class.
+;;; DECLARATION-DESCRIPTION classes.
+
+(defclass declaration-description (description name-mixin)
+  ())
+
+(defclass user-declaration-description (declaration-description name-mixin)
+  ())
+
+(defclass declarations-description (declaration-description declarations-mixin)
+  ())
 
 (defclass optimize-description
-    (description speed-mixin compilation-speed-mixin debug-mixin space-mixin safety-mixin)
-  ())
+    (declaration-description
+     speed-mixin compilation-speed-mixin debug-mixin space-mixin safety-mixin)
+  ((%name :initform :optimize)))

--- a/Code/query-functions.lisp
+++ b/Code/query-functions.lisp
@@ -19,7 +19,7 @@
 
 (defgeneric describe-tag (client environment tag))
 
-(defgeneric describe-optimize (client environment))
+(defgeneric describe-declaration (client environment identifier))
 
 ;;; Given an environment, this function returns the global
 ;;; environment.  If the environment given as an argument is the

--- a/Code/query-mixin-classes.lisp
+++ b/Code/query-mixin-classes.lisp
@@ -57,6 +57,9 @@
     %inline-data :inline-data inline-data
     :initform nil)
 
+(define-mixin-class declarations-mixin
+    %declarations :declarations declarations)
+
 (define-mixin-class speed-mixin
     %speed :speed speed)
 

--- a/Documentation/chap-query.tex
+++ b/Documentation/chap-query.tex
@@ -148,17 +148,26 @@ on the generic function \texttt{describe-tag} returns \texttt{nil}.
 This method returns the name of the tag for which no description was
 available.
 
-\subsection{Optimize information}
+\subsection{Declaration information}
 
 {\footnotesize
-\Defgeneric {describe-optimize} {client environment}
+\Defgeneric {describe-declaration} {client environment identifier}
 }
 
-Client-supplied methods on this function must always return a valid
-instance of the class \texttt{optimize-description}.  It returns an
-instance of the class described in
-\refSec{sec-instantiable-classes-optimize-desciption}.
+Client-supplied methods on this function must return a valid instance
+of the class \texttt{declaration-description} or \texttt{nil}.
 
+When \texttt{identifier} is \texttt{cl:optimize}, a valid instance
+of the class \texttt{optimize-description} must be returned.
+
+When \texttt{identifier} is \texttt{cl:declaration}, a valid
+instance of the class \texttt{declarations-description} must be
+returned.
+
+When \texttt{identifier} is not a valid declaration identifier,
+\texttt{nil} must be returned. Type specifiers are not considered
+to be valid declaration identifiers, and information about types
+must be obtained elsewhere.
 
 \section{Mixin classes}
 
@@ -542,6 +551,30 @@ inclusive.
 
 \Given{safety-mixin} the safety information, \Assupplied{:safety}
 
+\subsection{\texttt{declarations-mixin}}
+\label{sec-declarations-mixin}
+
+{\footnotesize
+\Defclass {declarations-mixin}
+}
+
+This class is a superclass of query classes that provide information
+about defined declaration identifiers. In particular, it is a
+superclass of the class \texttt{declarations-description}.
+
+{\footnotesize
+\Definitarg {:declarations}
+}
+
+The value of this initarg must be a list of declaration identifiers
+which are symbols.
+
+{\footnotesize
+\Defmethod {declarations} {(description {\tt descriptions-mixin})}
+}
+
+\Given{declarations-mixin} the declarations information, \Assupplied{:declarations}
+
 \section{Abstract query classes}
 
 {\footnotesize
@@ -796,3 +829,25 @@ This class is a subclass of the classes \texttt{name-mixin} and
 This class is a subclass of \texttt{speed-mixin},
 \texttt{compilation-speed-mixin}, \texttt{debug-mixin},
 \texttt{space-mixin}, and \texttt{safety-mixin}.
+
+\subsection{User declaration description}
+\label{sec-instantiable-classes-user-declaration-description}
+
+{\footnotesize
+\Defclass {user-declaration-description}
+}
+
+This class is a subclass of \texttt{name-mixin}. It describes
+declarations defined by a user with the \texttt{declaration}
+proclamation.
+
+\subsection{Declarations description}
+\label{sec-instantiable-classes-declarations-description}
+
+{\footnotesize
+\Defclass {declarations-description}
+}
+
+This class is a subclass of \texttt{declarations-mixin}.
+It has information about the list of declarations proclaimed
+with the \texttt{declaration} proclamation.


### PR DESCRIPTION
Defines a new `declaration-information` protocol function to allow querying the list of declarations defined with the `declaration` proclamation.

- New function `describe-declaration`. This is analogous to the CLTL2 function `declaration-information`: you pass a client, environment, and declaration identifier, and you get back a query object.
- Passing an identifier of `cl:declaration` gets you a `declarations-description` object, which has a list of declaration identifiers (symbols).
- Passing an identifier of `cl:optimize` gets you an `optimize-description`, which hasn't otherwise changed. **Incompatible API change:** `describe-optimize` is removed in favor of this, so beach's Cleavir will have to be changed a bit.
- Passing an identifier declared as a declaration identifier can get you a `user-declaration-description` or something else as the client wills.
- Type identifiers get you nothing, as do standard variable-oriented declarations like `dynamic-extent` and such.

No protocol for adding declarations lexically is defined, as there is no facility for this in the language. Relatedly, I didn't define any tests for the new protocol. The existing ones work for me on both SBCL and CCL, though.